### PR TITLE
fix: correct sign errors in putnam_like Set_6/A1 grading_scheme.md

### DIFF
--- a/eval_hub/putnam_like/putnam_like/Set_6/A1/rubrics/grading_scheme.md
+++ b/eval_hub/putnam_like/putnam_like/Set_6/A1/rubrics/grading_scheme.md
@@ -21,8 +21,8 @@ $$
 This step is worth 5 points.
 Doing standard calculations we see that:
 * $-C = (\alpha\beta\gamma)^2=c^2$,
-* $-A = (\alpha+\beta+\gamma)^2 - 2(\alpha\beta+\beta\gamma+\alpha\gamma) = a^2+2b$,
+* $-A = (\alpha+\beta+\gamma)^2 - 2(\alpha\beta+\beta\gamma+\alpha\gamma) = a^2-2b$,
 * $B = (\alpha\beta+\beta\gamma+\alpha\gamma)^2-2\alpha\beta\gamma(\alpha+\beta+\gamma) = b^2-2ac$.
 
 This step is worth 1 point.
-Answer: $x^3-(a^2+2b)x^2 + (b^2-2ac)x -c^2 = 0$.
+Answer: $x^3-(a^2-2b)x^2 + (b^2-2ac)x -c^2 = 0$.


### PR DESCRIPTION
Fixes #2

## Problem

The grading scheme for `putnam_like_set6_a1` contains incorrect signs in lines 24 and 28.

By Vieta's formulas for $x^3 + ax^2 + bx + c = (x-\alpha)(x-\beta)(x-\gamma)$:

- $\alpha+\beta+\gamma = -a$
- $\alpha\beta+\beta\gamma+\alpha\gamma = b$

Computing $-A = \alpha^2+\beta^2+\gamma^2$:

$$-A = (\alpha+\beta+\gamma)^2 - 2(\alpha\beta+\beta\gamma+\alpha\gamma) = (-a)^2 - 2(b) = a^2 - 2b$$

The file incorrectly had $a^2 + 2b$ instead of $a^2 - 2b$.

## Changes

- **Line 24**: `a^2+2b` → `a^2-2b`
- **Line 28** (answer): `a^2+2b` → `a^2-2b`
