### PR TITLE
fix: correct formula for b_N in putnam_like Set_3/B4 grading_scheme.md

### DIFF
--- a/eval_hub/putnam_like/putnam_like/Set_3/B4/rubrics/grading_scheme.md
+++ b/eval_hub/putnam_like/putnam_like/Set_3/B4/rubrics/grading_scheme.md
@@ -49,10 +49,10 @@ Hence the only pair that could satisfy the condition is $(\alpha,\beta)=(\frac 5
 This step is worth 3 points.
 Let $N$ be an integer in $[N_n,N_{n+1}]$ i.e. $N=N_n+m$. Then
 $$
-b_N=\frac{\sum_{k=1}^{N_n} \frac{k(k+1)(2k+1)}6+1+2+\ldots+m}{(N_n+m)^{\alpha}}
+b_N=\frac{b_{N_n}\cdot N_n^\alpha +1+2+\ldots+m}{(N_n+m)^{\alpha}}
 $$
 and we estimate
 $$
-b_{N_n}\cdot\frac{N_n^{\alpha}}{N_{n+1}^{\alpha}}=\frac{\sum_{k=1}^{N_n} \frac{k(k+1)(2k+1)}6}{N_{n+1}^{\alpha}}<b_N<\frac{\sum_{k=1}^{N_{n+1}} \frac{k(k+1)(2k+1)}6}{N_n^{\alpha}}=b_{N_{n+1}}\cdot\frac{N_{n+1}^{\alpha}}{N_{n}^{\alpha}}.
+b_{N_n}\cdot\frac{N_n^{\alpha}}{N_{n+1}^{\alpha}}<b_N<b_{N_{n+1}}\cdot\frac{N_{n+1}^{\alpha}}{N_{n}^{\alpha}}.
 $$
-Since $\lim_{n\to\infty} \frac{N_n}{N_{n+1}}=1$ by the squeeze theorem we get $\lim_{N\to\infty}b_N=\beta$.
+Since $\lim_{n\to\infty} \frac{N_n}{N_{n+1}}=1$, by the squeeze theorem we get $\lim_{N\to\infty}b_N=\beta$.


### PR DESCRIPTION
Fixes #3

## Problem

The grading scheme for `putnam_like_set3_b4` has an incorrect expression in the last step (the squeeze theorem argument). The formula for $b_N$ used an explicit sum $\sum_{k=1}^{N_n} \frac{k(k+1)(2k+1)}{6}$ which does not correctly represent $\sum_{k=1}^{N_n} a_k$ for this sequence.

Since $b_{N_n} = \frac{\sum_{k=1}^{N_n} a_k}{N_n^\alpha}$, we have $\sum_{k=1}^{N_n} a_k = b_{N_n} \cdot N_n^\alpha$.

## Changes

**Line 52** — Replaced the incorrect sum expression:

```diff
-b_N=\frac{\sum_{k=1}^{N_n} \frac{k(k+1)(2k+1)}6+1+2+\ldots+m}{(N_n+m)^{\alpha}}
+b_N=\frac{b_{N_n}\cdot N_n^\alpha +1+2+\ldots+m}{(N_n+m)^{\alpha}}
```

**Line 56** — Simplified the squeeze theorem bounds by removing incorrect intermediate equalities:

```diff
-b_{N_n}\cdot\frac{N_n^{\alpha}}{N_{n+1}^{\alpha}}=\frac{\sum_{k=1}^{N_n} \frac{k(k+1)(2k+1)}6}{N_{n+1}^{\alpha}}<b_N<\frac{\sum_{k=1}^{N_{n+1}} \frac{k(k+1)(2k+1)}6}{N_n^{\alpha}}=b_{N_{n+1}}\cdot\frac{N_{n+1}^{\alpha}}{N_{n}^{\alpha}}.
+b_{N_n}\cdot\frac{N_n^{\alpha}}{N_{n+1}^{\alpha}}<b_N<b_{N_{n+1}}\cdot\frac{N_{n+1}^{\alpha}}{N_{n}^{\alpha}}.
```

As noted in the issue, these corrections do not impact the final answer or the overall idea of the solution.
